### PR TITLE
Add response schemas and a good_mock_server for v1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ export PYTHONPATH=<absolute path to drs-compliance-suite>
 
 ## Running natively in a developer environment
 
-* First spin up a DRS starter kit on port 5000 or a port of your choice. Make sure to specify the port number correctly in the next step.
+* First spin up a DRS starter kit on port 8085 or a port of your choice. Make sure to specify the port number correctly in the next step.
 * The following command will run the DRS complaince suite against the specified DRS implementation.
 ``` 
-python compliance_suite/report_runner.py --server_base_url "http://localhost:5000/ga4gh/drs/v1" --platform_name "ga4gh starter kit drs" --platform_description "GA4GH reference implementation of DRS specification" --auth_type "basic"
+python compliance_suite/report_runner.py --server_base_url "http://localhost:8085/ga4gh/drs/v1" --platform_name "ga4gh starter kit drs" --platform_description "GA4GH reference implementation of DRS specification" --auth_type "basic"
 ```
 ### Command Line Arguments
 #### <TODO: Add a table with default values, data type !!>
@@ -56,13 +56,25 @@ Depending on the auth type selected, the appropriate credentials must be provide
   * "bearer" : compliance_suite/config/config_bearer.json
   * "passport" : compliance_suite/config/config_passport.json
 
-## Running the good mock server
+## Running the good mock server that follows DRS v1.2.0 specification on port 8085
 ```
-python unittests/good_mock_server.py --auth_type "none" --app_host "0.0.0.0" --app_port "8089"
+python unittests/good_mock_server_v1.2.0.py --auth_type "none" --app_host "0.0.0.0" --app_port "8085"
 ```
+
 Make sure that the good mock server is running smoothly by making a GET request to 
 ```
-http://localhost:8089/ga4gh/drs/v1/service-info
+http://localhost:8085/ga4gh/drs/v1/service-info
+```
+You should get a response status of 200
+
+## Running the good mock server that follows DRS v1.3.0 specification on port 8086
+```
+python unittests/good_mock_server_v1.3.0.py --auth_type "none" --app_host "0.0.0.0" --app_port "8086"
+```
+
+Make sure that the good mock server is running smoothly by making a GET request to
+```
+http://localhost:8086/ga4gh/drs/v1/service-info
 ```
 You should get a response status of 200
 
@@ -81,7 +93,8 @@ You should get a response status of 200
 Note: Both bad and good mock servers should be running beforehand
 #### Running the mock servers
 ```
-python unittests/good_mock_server.py --auth_type "none" --app_host "0.0.0.0" --app_port "8089"
+python unittests/good_mock_server_v1.2.0.py --auth_type "none" --app_host "0.0.0.0" --app_port "8085"
+python unittests/good_mock_server_v1.3.0.py --auth_type "none" --app_host "0.0.0.0" --app_port "8086"
 python unittests/bad_mock_server.py --auth_type "none" --app_host "0.0.0.0" --app_port "8088"
 ```
 ###### Run the tests

--- a/compliance_suite/report_runner.py
+++ b/compliance_suite/report_runner.py
@@ -84,19 +84,6 @@ def report_runner(server_base_url, platform_name, platform_description, auth_typ
         case_description = "check if the content-type is " + expected_content_type,
         response = response)
 
-    # if any of the above two cases fail, the report runner
-    # will not be able to obtain the server's implemented DRS version number.
-    # Finalize and return report
-    for this_case in service_info_test.get_cases():
-        if this_case.get_status() != Status.PASS:
-            service_info_test.set_message("Stopping the report as the implemented DRS version "
-                                          "can not be obtained from the service-info endpoint")
-            service_info_test.set_end_time_now()
-            service_info_phase.set_end_time_now()
-            report_object.set_end_time_now()
-            report_object.finalize()
-            return report_object.to_json()
-
     ### CASE: response schema
     add_case_response_schema(
         test_object = service_info_test,
@@ -106,14 +93,22 @@ def report_runner(server_base_url, platform_name, platform_description, auth_typ
         response = response)
 
     # Get the DRS version number from service-info
-    # If the version is not supported by the compliance suite,
+    # If the version is not avaible or is supported by the compliance suite,
     # finalize and return report
 
     response_json = response.json()
     server_drs_version = None
     if "type" in response_json and "version" in response_json["type"]:
         server_drs_version = response_json["type"]["version"]
-    if server_drs_version not in SUPPORTED_DRS_VERSIONS \
+    if server_drs_version is None:
+        service_info_test.set_message("Stopping the report as the implemented DRS version "
+                                      "can not be obtained from the service-info endpoint")
+        service_info_test.set_end_time_now()
+        service_info_phase.set_end_time_now()
+        report_object.set_end_time_now()
+        report_object.finalize()
+        return report_object.to_json()
+    elif server_drs_version not in SUPPORTED_DRS_VERSIONS \
             or response_json["type"]["artifact"].lower() != "drs":
         service_info_test.set_message("Stopping the report as the implemented DRS version " + server_drs_version +
                                       " is not supported by this Compliance Suite. "

--- a/compliance_suite/report_runner.py
+++ b/compliance_suite/report_runner.py
@@ -93,7 +93,7 @@ def report_runner(server_base_url, platform_name, platform_description, auth_typ
         response = response)
 
     # Get the DRS version number from service-info
-    # If the version is not avaible or is supported by the compliance suite,
+    # If the version is not available or is not supported by the compliance suite,
     # finalize and return report
 
     response_json = response.json()

--- a/compliance_suite/schemas/v1.3.0/access_method.json
+++ b/compliance_suite/schemas/v1.3.0/access_method.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Access Method object",
+  "type": "object",
+  "$ref": "access_method.json#/definitions/access_method",
+  "definitions": {
+    "access_method": {
+      "type": "object",
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "s3",
+            "gs",
+            "ftp",
+            "gsiftp",
+            "globus",
+            "htsget",
+            "https",
+            "file"
+          ],
+          "description": "Type of the access method."
+        },
+        "access_url": {
+          "allOf": [
+            {
+              "$ref": "access_url.json#/definitions/access_url"
+            },
+            {
+              "description": "An `AccessURL` that can be used to fetch the actual object bytes. Note that at least one of `access_url` and `access_id` must be provided."
+            }
+          ]
+        },
+        "access_id": {
+          "type": "string",
+          "description": "An arbitrary string to be passed to the `/access` method to get an `AccessURL`. This string must be unique within the scope of a single object. Note that at least one of `access_url` and `access_id` must be provided."
+        },
+        "region": {
+          "type": "string",
+          "description": "Name of the region in the cloud service provider that the object belongs to.",
+          "example": "us-east-1"
+        },
+        "authorizations": {
+          "allOf": [
+            {
+              "$ref": "authorizations.json#/definitions/authorizations"
+            },
+            {
+              "description": "When `access_id` is provided, `authorizations` provides information about how to authorize the `/access` method."
+            }
+          ]
+        },
+        "required": [
+          "type"
+        ],
+        "additionalProperties": false
+      }
+    }
+  }
+}

--- a/compliance_suite/schemas/v1.3.0/access_url.json
+++ b/compliance_suite/schemas/v1.3.0/access_url.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Access URL",
+  "type": "object",
+  "$ref": "access_url.json#/definitions/access_url",
+  "definitions": {
+    "access_url": {
+      "type": "object",
+      "properties": {
+        "url": {
+          "type": "string",
+          "description": "A fully resolvable URL that can be used to fetch the actual object bytes."
+        },
+        "headers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "An optional list of headers to include in the HTTP request to `url`. These headers can be used to provide auth tokens required to fetch the object bytes."
+        }
+      },
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false
+    }
+  }
+}

--- a/compliance_suite/schemas/v1.3.0/authorizations.json
+++ b/compliance_suite/schemas/v1.3.0/authorizations.json
@@ -1,0 +1,41 @@
+{"$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Authorizations",
+  "type": "object",
+  "$ref": "quthorizations.json#/definitions/authorizations",
+  "definitions": {
+    "authorizations": {
+      "type": "object",
+      "properties": {
+        "supported_types": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "None",
+              "BasicAuth",
+              "BearerAuth",
+              "PassportAuth"
+            ]
+          },
+          "description": "An Optional list of support authorization types. More than one can be supported and tried in sequence. Defaults to `None` if empty or missing."
+        },
+        "passport_auth_issuers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "If authorizations contain `PassportAuth` this is a required list of visa issuers (as found in a visa's `iss` claim) that may authorize access to this object. The caller must only provide passports that contain visas from this list. It is strongly recommended that the caller validate that it is appropriate to send the requested passport/visa to the DRS server to mitigate attacks by malicious DRS servers requesting credentials they should not have."
+        },
+        "bearer_auth_issuers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "If authorizations contain `BearerAuth` this is an optional list of issuers that may authorize access to this object. The caller must provide a token from one of these issuers. If this is empty or missing it assumed the caller knows which token to send via other means. It is strongly recommended that the caller validate that it is appropriate to send the requested token to the DRS server to mitigate attacks by malicious DRS servers requesting credentials they should not have."
+        }
+      },
+      "required": [],
+      "additionalProperties": false
+    }
+  }
+}

--- a/compliance_suite/schemas/v1.3.0/checksum.json
+++ b/compliance_suite/schemas/v1.3.0/checksum.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Checksum",
+  "type": "object",
+  "$ref": "checksum.json#/definitions/checksum",
+  "definitions": {
+    "checksum": {
+      "type": "object",
+      "properties": {
+        "checksum": {
+          "type": "string",
+          "description": "The hex-string encoded checksum for the data"
+        },
+        "type": {
+          "type": "string",
+          "description": "The digest method used to create the checksum. The value (e.g. `sha-256`) SHOULD be listed as `Hash Name String` in the https://www.iana.org/assignments/named-information/named-information.xhtml#hash-alg[IANA Named Information Hash Algorithm Registry]. Other values MAY be used, as long as implementors are aware of the issues discussed in https://tools.ietf.org/html/rfc6920#section-9.4[RFC6920]. GA4GH may provide more explicit guidance for use of non-IANA-registered algorithms in the future. Until then, if implementers do choose such an algorithm (e.g. because it's implemented by their storage provider), they SHOULD use an existing standard `type` value such as `md5`, `etag`, `crc32c`, `trunc512`, or `sha1`."
+        }
+      },
+      "required": [
+        "checksum",
+        "type"
+      ],
+      "additionalProperties": false
+    }
+  }
+}

--- a/compliance_suite/schemas/v1.3.0/contents_object.json
+++ b/compliance_suite/schemas/v1.3.0/contents_object.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Contents Object",
+  "type": "object",
+  "$ref": "contents_object.json#/definitions/contents_object",
+  "definitions": {
+    "content_object": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "A name declared by the bundle author that must be used when materialising this object, overriding any name directly associated with the object itself. The name must be unique within the containing bundle. This string is made up of uppercase and lowercase letters, decimal digits, hyphen, period, and underscore [A-Za-z0-9.-_]. See http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_282[portable filenames]."
+        },
+        "id": {
+          "type": "string",
+          "description": "A DRS identifier of a `DrsObject` (either a single blob or a nested bundle). If this ContentsObject is an object within a nested bundle, then the id is optional. Otherwise, the id is required."
+        },
+        "drs_uri": {
+          "type": "array",
+          "description": "A list of full DRS identifier URI paths that may be used to obtain the object. These URIs may be external to this DRS instance.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "contents": {
+          "type": "array",
+          "description": "If this ContentsObject describes a nested bundle and the caller specified \"?expand=true\" on the request, then this contents array must be present and describe the objects within the nested bundle.",
+          "items": {
+            "$ref": "contents_object.json#/definitions/contents_object"
+          }
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "additionalProperties": false
+    }
+  }
+}

--- a/compliance_suite/schemas/v1.3.0/drs_object.json
+++ b/compliance_suite/schemas/v1.3.0/drs_object.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "DRS object info",
+  "description": "DRS object info v1.2",
+  "type": "object",
+  "$ref": "drs_object.json#/definitions/drs_object",
+  "definitions": {
+    "drs_object": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "An identifier unique to this `DrsObject`"
+        },
+        "name": {
+          "type": "string",
+          "description": "A string that can be used to name a `DrsObject`.\nThis string is made up of uppercase and lowercase letters, decimal digits, hyphen, period, and underscore [A-Za-z0-9.-_]. See http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_282[portable filenames]."
+        },
+        "self_uri": {
+          "type": "string",
+          "description": "A drs:// hostname-based URI, as defined in the DRS documentation, that tells clients how to access this object.\nThe intent of this field is to make DRS objects self-contained, and therefore easier for clients to store and pass around.  For example, if you arrive at this DRS JSON by resolving a compact identifier-based DRS URI, the `self_uri` presents you with a hostname and properly encoded DRS ID for use in subsequent `access` endpoint calls."
+        },
+        "size": {
+          "type": "integer",
+          "description": "For blobs, the blob size in bytes.\nFor bundles, the cumulative size, in bytes, of items in the `contents` field."
+        },
+        "created_time": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp of content creation in RFC3339.\n(This is the creation time of the underlying content, not of the JSON object.)"
+        },
+        "updated_time": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp of content update in RFC3339, identical to `created_time` in systems that do not support updates. (This is the update time of the underlying content, not of the JSON object.)"
+        },
+        "version": {
+          "type": "string",
+          "description": "A string representing a version. (Some systems may use checksum, a RFC3339 timestamp, or an incrementing version number.)"
+        },
+        "mime_type": {
+          "type": "string",
+          "description": "A string providing the mime-type of the `DrsObject`."
+        },
+        "checksums": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "checksum.json#/definitions/checksum"
+          },
+          "description": "The checksum of the `DrsObject`. At least one checksum must be provided. For blobs, the checksum is computed over the bytes in the blob. For bundles, the checksum is computed over a sorted concatenation of the checksums of its top-level contained objects (not recursive, names not included). The list of checksums is sorted alphabetically (hex-code) before concatenation and a further checksum is performed on the concatenated checksum value. For example, if a bundle contains blobs with the following checksums: md5(blob1) = 72794b6d md5(blob2) = 5e089d29 Then the checksum of the bundle is: md5( concat( sort( md5(blob1), md5(blob2) ) ) ) = md5( concat( sort( 72794b6d, 5e089d29 ) ) ) = md5( concat( 5e089d29, 72794b6d ) ) = md5( 5e089d2972794b6d ) = f7a29a04"
+        },
+        "access_methods": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "access_method.json#/definitions/access_method"
+          },
+          "description": "The list of access methods that can be used to fetch the `DrsObject`.\nRequired for single blobs; optional for bundles."
+        },
+        "contents": {
+          "type": "array",
+          "description": "If not set, this `DrsObject` is a single blob. If set, this `DrsObject` is a bundle containing the listed `ContentsObject` s (some of which may be further nested).",
+          "items": {
+            "$ref": "contents_object.json#/definitions/contents_object"
+          }
+        },
+        "description": {
+          "type": "string",
+          "description": "A human readable description of the `DrsObject`."
+        },
+        "aliases": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "A list of strings that can be used to find other metadata about this `DrsObject` from external metadata sources. These aliases can be used to represent secondary accession numbers or external GUIDs."
+        }
+      },
+      "required": [
+        "id",
+        "self_uri",
+        "size",
+        "created_time",
+        "checksums"
+      ],
+      "additionalProperties": true
+    }
+  }
+}

--- a/compliance_suite/schemas/v1.3.0/error.json
+++ b/compliance_suite/schemas/v1.3.0/error.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Error Response",
+  "type": "object",
+  "description": "An object that can optionally include information about the error.",
+  "$ref": "error.json#/definitions/error",
+  "definitions": {
+    "error": {
+      "type": "object",
+      "properties": {
+        "msg": {
+          "type": "string",
+          "description": "A detailed error message."
+        },
+        "status_code": {
+          "type": "integer",
+          "description": "The integer representing the HTTP status code (e.g. 200, 404)."
+        }
+      },
+      "additionalProperties": true
+    }
+  }
+}

--- a/unittests/good_mock_server_v1.2.0.py
+++ b/unittests/good_mock_server_v1.2.0.py
@@ -1,0 +1,287 @@
+from flask import Flask, request, Response
+import datetime
+from edit_data import get_drs_object, get_drs_access_url, get_drs_object_passport
+from flask_httpauth import HTTPBasicAuth, HTTPTokenAuth
+from werkzeug.security import generate_password_hash, check_password_hash
+from helper import parse_args
+import json
+
+app = Flask(__name__)
+args = parse_args()
+app.config["auth_type"] = args.auth_type
+users = {
+    "username": generate_password_hash("password")
+}
+tokens = {
+    "secret-bearer-token-1": "user-1"
+}
+
+auth_basic = HTTPBasicAuth()
+auth_bearer = HTTPTokenAuth(scheme="Bearer")
+
+def conditional_auth(auth_config):
+    def decorator(func):
+        if auth_config == "none":
+            # Return the function unchanged, not decorated.
+            return func
+        elif auth_config == "basic":
+            return auth_basic.login_required(func)
+        elif auth_config == "bearer":
+            return auth_bearer.login_required(func)
+        elif auth_config == "passport":
+            return func #TODO: FAIL!!!
+        return func
+    return decorator
+
+@auth_bearer.verify_token
+def verify_token(token):
+    if token in tokens:
+        return tokens[token]
+
+
+@auth_basic.verify_password
+def verify_password(username, password):
+    if username in users and \
+            check_password_hash(users.get(username), password):
+        return username
+
+'''
+HTTP codes
+200: "Retrieve info about the DRS service"
+500: "An unexpected error occured"
+'''
+
+# Get service info
+@app.route('/ga4gh/drs/v1/service-info', methods=['GET'])
+@conditional_auth(app.config["auth_type"])
+def get_service_info():
+    header_content = request.headers
+    accept_type = "application/json"
+
+    # validate the accept header
+    if "accept" in header_content and header_content["accept"] not in [accept_type, "*/*"]:
+        return Response(status=406)
+
+    service_info_resp = {
+        "id": "org.ga4gh.starterkit.drs",
+        "name": "GA4GH Starter Kit DRS Service",
+        "description": "An open source, community-driven implementation of the GA4GH Data Repository Service (DRS) API specification.",
+        "contactUrl": "mailto:info@ga4gh.org",
+        "documentationUrl": "https://github.com/ga4gh/ga4gh-starter-kit-drs",
+        "environment": "test",
+        "version": "0.3.1",
+        "type": {
+            "group": "org.ga4gh",
+            "artifact": "drs",
+            "version": "1.2.0"
+        },
+        "organization": {
+            "name": "Global Alliance for Genomics and Health",
+            "url": "https://ga4gh.org"
+        }
+    }
+
+    return Response(response=json.dumps(service_info_resp), status=200, mimetype=accept_type)
+
+'''
+HTTP codes
+200: "The DRS object was found successfully"
+202: "The operation is delayed and will continue asynchronously"
+400: "The request is malformed",
+401: "The request is unauthorized",
+403: "The requestor is not authorized to perform this action",
+404: "The requested DRS object was not Found",
+500: "An unexpected error occured"
+'''
+
+# GET Info about a DRS Object or
+# GET Info about a DRS Object through POST'ing a Passport
+@app.route('/ga4gh/drs/v1/objects/<obj_id>', methods=['GET','POST'])
+@conditional_auth(app.config["auth_type"])
+def get_object(obj_id):
+    expand = request.args.get('expand', "False")
+
+    # convert param to bool
+    if expand.lower() == "true": 
+        expand = True
+    else:
+        expand = False
+    accept_type = "application/json"
+    drs_obj = get_drs_object(obj_id, expand)
+    if request.method == "GET" and app.config["auth_type"]!="passport":
+        if not drs_obj: # Object not found
+            error_obj = {
+                "timestamp": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "status_code": 404,
+                "error": "Not Found",
+                "msg": "No DrsObject found by id: " + obj_id
+            }
+            return Response(response=json.dumps(error_obj), status=404, mimetype=accept_type)
+        return Response(response=json.dumps(drs_obj), status=200, mimetype=accept_type)
+
+    elif request.method == "POST" and app.config["auth_type"]=="passport":
+        header_content = request.headers
+        accept_type = "application/json"
+
+        if not drs_obj: # Object not found
+            error_obj = {
+                "timestamp": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "status_code": 404,
+                "error": "Not Found",
+                "msg": "No DrsObject found by id: " + obj_id
+            }
+            return Response(response=json.dumps(error_obj), status=404, mimetype=accept_type)
+
+        if app.config["auth_type"]=="passport" and ("accept" in header_content and header_content["accept"] in [accept_type, "*/*"]):
+            try:
+                request_body = request.get_json()
+
+                if "expand" in request_body:
+                    if isinstance(request_body["expand"], bool):                    
+                        expand = request_body["expand"]
+                    elif isinstance(request_body["expand"], str):
+                        if request_body["expand"].lower() == "true": 
+                            expand = True
+                        else:
+                            expand = False 
+                    else:
+                        expand = False
+                
+                drs_obj = get_drs_object(obj_id, expand)
+
+                drs_obj_passport = get_drs_object_passport(obj_id)
+                if not request_body["passports"]:
+                    error_obj = {
+                        "timestamp": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                        "status_code": 401,
+                        "error": "Request is unauthorized",
+                        "msg": "A passport is required to authorize the request"
+                    }
+                    return Response(response=json.dumps(error_obj), status=401, mimetype=accept_type)
+                elif drs_obj_passport in request_body["passports"]:
+                    return Response(response=json.dumps(drs_obj), status=200, mimetype=accept_type)
+                else:
+                    error_obj = {
+                        "timestamp": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                        "status_code": 403,
+                        "error": "The requestor is not authorized to perform this action",
+                        "msg": "The passport provided does not grant access to the requested resource"
+                    }
+                    return Response(response=json.dumps(error_obj), status=403, mimetype=accept_type)
+            except Exception as ex:
+                error_obj = {
+                    "timestamp": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    "status_code": 500,
+                    "error": "An unexpected error occured",
+                    "msg": "An unexpected error occured. Exception: " + str(ex) +
+                           ". POST method can be used only if the app is running with auth_type as 'passport'. "
+                           "Content-Type must be 'application/json"
+                }
+            return Response(response=json.dumps(error_obj), status=500, mimetype=accept_type)
+
+        else:
+            error_obj = {
+                "timestamp": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "status_code": 500,
+                "error": "An unexpected error occured",
+                "msg": "An unexpected error occured. POST method can be used only if the app is running with auth_type as 'passport'. "
+                       "Content-Type must be 'application/json'"
+            }
+            return Response(response=json.dumps(error_obj), status=500, mimetype=accept_type)
+    else:
+        error_obj = {
+            "timestamp": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "status_code": 400,
+            "error": "The request is malformed",
+            "msg": "HTTP Method Not Allowed"
+        }
+        return Response(response=json.dumps(error_obj), status=400, mimetype=accept_type)
+
+
+# Get a URL for fetching bytes or
+# Get a URL for fetching bytes through POST'ing Passport
+@app.route('/ga4gh/drs/v1/objects/<obj_id>/access/<access_id>', methods=['GET', 'POST'])
+@conditional_auth(app.config["auth_type"])
+def get_access_url(obj_id, access_id):
+    accept_type = "application/json"
+    access_url_obj = get_drs_access_url(obj_id, access_id)
+
+    if request.method == "GET" and app.config["auth_type"]!="passport":
+        if access_url_obj:
+            # Object found
+            return Response(response=json.dumps(access_url_obj), status=200, mimetype=accept_type)
+        else:
+            # Object not found
+            error_obj = {
+                "timestamp": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "status_code": 404,
+                "error": "Not Found",
+                "msg": "The requested access url wasn't found"
+            }
+
+            return Response(response=json.dumps(error_obj), status=404, mimetype=accept_type)
+    elif request.method == "POST" and app.config["auth_type"]=="passport":
+        header_content = request.headers
+        accept_type = "application/json"
+
+        if not access_url_obj: # Object not found
+            error_obj = {
+                "timestamp": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "status_code": 404,
+                "error": "Not Found",
+                "msg": "No access url found for drs id: " + obj_id + " and access_id: " + access_id
+            }
+            return Response(response=json.dumps(error_obj), status=404, mimetype=accept_type)
+
+        if app.config["auth_type"]=="passport" and ("accept" in header_content and header_content["accept"] in [accept_type, "*/*"]):
+            try:
+                request_body = request.get_json()
+                drs_obj_passport = get_drs_object_passport(obj_id)
+                if not request_body["passports"]:
+                    error_obj = {
+                        "timestamp": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                        "status_code": 401,
+                        "error": "Request is unauthorized",
+                        "msg": "A passport is required to authorize the request"
+                    }
+                    return Response(response=json.dumps(error_obj), status=401, mimetype=accept_type)
+                elif drs_obj_passport in request_body["passports"]:
+                    return Response(response=json.dumps(access_url_obj), status=200, mimetype=accept_type)
+                else:
+                    error_obj = {
+                        "timestamp": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                        "status_code": 403,
+                        "error": "The requestor is not authorized to perform this action",
+                        "msg": "The passport provided does not grant access to the requested resource"
+                    }
+                    return Response(response=json.dumps(error_obj), status=403, mimetype=accept_type)
+            except Exception as ex:
+                error_obj = {
+                    "timestamp": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    "status_code": 500,
+                    "error": "An unexpected error occured",
+                    "msg": "An unexpected error occured. Exception: " + str(ex) +
+                           ". POST method can be used only if the app is running with auth_type as 'passport'. "
+                           "Content-Type must be 'application/json"
+                }
+            return Response(response=json.dumps(error_obj), status=500, mimetype=accept_type)
+        else:
+            error_obj = {
+                "timestamp": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "status_code": 500,
+                "error": "An unexpected error occured",
+                "msg": "An unexpected error occured. POST method can be used only if the app is running with auth_type as 'passport'. "
+                       "Content-Type must be 'application/json'"
+            }
+            return Response(response=json.dumps(error_obj), status=500, mimetype=accept_type)
+    else:
+        error_obj = {
+            "timestamp": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "status_code": 400,
+            "error": "The request is malformed",
+            "msg": "HTTP Method Not Allowed"
+        }
+        return Response(response=json.dumps(error_obj), status=400, mimetype=accept_type)
+
+if __name__=="__main__":
+    app.run(host=args.app_host,port=args.app_port)


### PR DESCRIPTION
- Report runner does not terminate if service-info endpoint validation fails. Instead, it only terminates without finishing all the tests only when the DRS server version is not obtained from the service-info endpoint or if the obtained DRS version is not supported by the DRS compliance suite
- Add response schemas for DRS v1.3.0 in `compliance_suite/schemas/v1.3.0` directory
- Rename existing good_mock_server.py to `good_mock_server_v1.2.0.py`
- Create a new good_mock_server that follows DRS v1.3.0 - `good_mock_server_v1.3.0.py`
- Update README 