### PR TITLE
Get access_id values from drs object response

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -6,6 +6,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    - name: Set up PYTHONPATH
+      run: echo "PYTHONPATH=$(pwd)" >> $GITHUB_ENV
+
     - uses: actions/setup-python@v4
       with:
         python-version: '3.9.13'
@@ -13,8 +16,10 @@ jobs:
 
     - run: pip install -r requirements.txt # download pip dependencies
 
+    - run: echo $PYTHONPATH
+
     - name: Running Tests
-      run: "pytest -v"
+      run: "pytest --cov=compliance_suite unittests/"
 
     # FOR FUTURE PR: CODE TEST COVERAGE
     # - name: After Success Submitting Code Coverage

--- a/README.md
+++ b/README.md
@@ -101,11 +101,8 @@ python unittests/good_mock_server_v1.2.0.py --auth_type "none" --app_host "0.0.0
 python unittests/good_mock_server_v1.3.0.py --auth_type "none" --app_host "0.0.0.0" --app_port "8086"
 python unittests/bad_mock_server.py --auth_type "none" --app_host "0.0.0.0" --app_port "8088"
 ```
-###### Run the tests
-```
-py.test -v
-```
-###### Check the code coverage of the tests
+
+###### Running the tests with code coverage
 ```
 pytest --cov=compliance_suite unittests/ 
 ```

--- a/compliance_suite/config/input_drs_objects.json
+++ b/compliance_suite/config/input_drs_objects.json
@@ -1,20 +1,16 @@
 {
   "drs_objects" : [
     {
-      "drs_id" : "697907bf-d5bd-433e-aac2-1747f1faf366",
-      "access_id" : "338e433b-e0f4-4261-9d25-1863b2dcf08d"
+      "drs_id" : "697907bf-d5bd-433e-aac2-1747f1faf366"
     },
     {
-      "drs_id" : "0bb9d297-2710-48f6-ab4d-80d5eb0c9eaa",
-      "access_id" : "087c70d5-64ac-4ec8-ad32-46e68f3480f5"
+      "drs_id" : "0bb9d297-2710-48f6-ab4d-80d5eb0c9eaa"
     },
     {
-      "drs_id" : "1af6b862-7fc8-411a-86c5-d8e280e5b77a",
-      "access_id" : "753e47fd-1a68-43c3-90c4-05b11db7dee7"
+      "drs_id" : "1af6b862-7fc8-411a-86c5-d8e280e5b77a"
     },
     {
-      "drs_id" : "41898242-62a9-4129-9a2c-5a4e8f5f0afb",
-      "access_id" : "ac4e572a-be54-4343-ad46-0b1ab8ebe326"
+      "drs_id" : "41898242-62a9-4129-9a2c-5a4e8f5f0afb"
     }
   ]
 }

--- a/compliance_suite/validate_drs_object_response.py
+++ b/compliance_suite/validate_drs_object_response.py
@@ -1,0 +1,53 @@
+from compliance_suite.validate_response import ValidateResponse
+from ga4gh.testbed.report.status import Status
+
+class ValidateDRSObjectResponse(ValidateResponse):
+    def __init__(self):
+        super().__init__()
+
+    def validate_has_access_methods(self):
+        """
+        Validates that "access_methods" are provided and non-empty
+        """
+        if self.case.get_status() == Status.SKIP: # TODO: if is_bundle then SKIP this test case
+            self.case.set_end_time_now()
+            return
+        else:
+            response_json = self.actual_response.json()
+            if ("access_methods" in response_json and response_json["access_methods"]):
+                self.case.set_message("'access_methods' is provided and it is non-empty.")
+                self.case.set_status_pass()
+            else:
+                self.case.set_message("'access_methods' is not provided. It is required and should be non-empty for a single-blob")
+                self.case.set_status_fail()
+            self.case.set_end_time_now()
+        return
+
+    def validate_has_access_info(self):
+        access_id_list = []
+        if self.case.get_status() == Status.SKIP:
+            self.case.set_end_time_now()
+            return access_id_list
+
+        response_json = self.actual_response.json()
+        access_methods = response_json.get("access_methods", [])
+        methods_with_no_access_info = []
+
+        for i in range(len(access_methods)):
+            access_method = access_methods[i]
+            if "access_url" not in access_method and "access_id" not in access_method:
+                methods_with_no_access_info.append(str(i+1))
+            if "access_id" in access_method:
+                access_id_list.append(access_method["access_id"])
+        if (not methods_with_no_access_info) and access_methods:
+            self.case.set_message(f"At least 'access_url' or 'access_id' is provided in all access_methods")
+            self.case.set_status_pass()
+        elif not access_methods:
+            self.case.set_message(f"access_methods is not provided. It is required and should be non-empty for a single-blob")
+            self.case.set_status_fail()
+        else:
+            self.case.set_message(f"Neither 'access_url' nor 'access_id' is provided in some or all access_methods - {', '.join(methods_with_no_access_info)}")
+            self.case.set_status_fail()
+
+        self.case.set_end_time_now()
+        return access_id_list

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pytest==7.1.2
 pytest-cov==3.0.0
 ga4gh-testbed-lib==0.2.0
 jsonschema==4.12.1
+parameterized==0.9.0

--- a/unittests/data/drs_object_access_url_mapping.json
+++ b/unittests/data/drs_object_access_url_mapping.json
@@ -6,19 +6,19 @@
         }
     },
     "0bb9d297-2710-48f6-ab4d-80d5eb0c9eaa": {
-        "accessId": "087c70d5-64ac-4ec8-ad32-46e68f3480f5",
+        "accessId": "db070dcb-15cd-4a28-aa84-c7b3caa4f43a",
         "url": {
             "url": "http://localhost:4500/ga4gh/drs/v1/stream/0bb9d297-2710-48f6-ab4d-80d5eb0c9eaa/087c70d5-64ac-4ec8-ad32-46e68f3480f5"
         }
     },
     "1af6b862-7fc8-411a-86c5-d8e280e5b77a": {
-        "accessId": "753e47fd-1a68-43c3-90c4-05b11db7dee7",
+        "accessId": "73fec6d9-3de7-4c92-8ca4-96d6dafaace9",
         "url": {
             "url": "http://localhost:4500/ga4gh/drs/v1/stream/1af6b862-7fc8-411a-86c5-d8e280e5b77a/753e47fd-1a68-43c3-90c4-05b11db7dee7"
         }
     },
     "41898242-62a9-4129-9a2c-5a4e8f5f0afb": {
-        "accessId": "ac4e572a-be54-4343-ad46-0b1ab8ebe326",
+        "accessId": "9488e423-d243-4d08-807c-d35be1b144f1",
         "url": {
             "url": "http://localhost:4500/ga4gh/drs/v1/stream/41898242-62a9-4129-9a2c-5a4e8f5f0afb/ac4e572a-be54-4343-ad46-0b1ab8ebe326"
         }

--- a/unittests/resources/mock_drs_response_access_methods.py
+++ b/unittests/resources/mock_drs_response_access_methods.py
@@ -1,0 +1,29 @@
+from unittests.utils import MockResponse
+
+# access_methods are present but empty
+mock_response_0 = MockResponse(response = {"access_methods" : []})
+
+# access_methods are absent
+mock_response_1 = MockResponse(response = {"test_key" : "test_value"})
+
+# Access methods are present, with one method containing "access_id" and another method containing "access_url"
+mock_response_2 = MockResponse(response = {"access_methods" : [
+    {"access_id":"338e433b-e0f4-4261-9d25-1863b2dcf08d","type":"https"},
+    {"access_url":{"url":"s3://ga4gh-demo-data/phenopackets/Zhang-2009-EDA-proband.json"},"type":"s3","region":"us-east-2"}
+]})
+
+# Access methods are present, with one method containing "access_id",
+# another method containing "access_url", and the last method being empty.
+mock_response_3 = MockResponse(response = {"access_methods" : [
+    {"access_id":"338e433b-e0f4-4261-9d25-1863b2dcf08d","type":"https"},
+    {"access_url":{"url":"s3://ga4gh-demo-data/phenopackets/Zhang-2009-EDA-proband.json"},"type":"s3","region":"us-east-2"},
+    {}
+]})
+
+# Access methods are present, with one method containing "access_id",
+# another method containing "access_url", and the last method containing both "access_id" and "access_url".
+mock_response_4 = MockResponse(response = {"access_methods" : [
+    {"access_id":"338e433b-e0f4-4261-9d25-1863b2dcf08d","type":"https"},
+    {"access_url":{"url":"s3://ga4gh-demo-data/phenopackets/Zhang-2009-EDA-proband.json"},"type":"s3","region":"us-east-2"},
+    {"access_id":"338e433b-e0f4-4261-9d25-1863b2dcf08f","access_url":{"url":"s3://ga4gh-demo-data/phenopackets/Zhang-2009-EDA-proband.json"},"type":"http"}
+]})

--- a/unittests/v1.2.0/test_report_runner.py
+++ b/unittests/v1.2.0/test_report_runner.py
@@ -1,0 +1,37 @@
+import unittest
+from parameterized import parameterized
+from compliance_suite.report_runner import add_access_methods_test_case
+from unittest.mock import patch, Mock
+
+class TestReportRunner(unittest.TestCase):
+
+    @parameterized.expand([
+        ("has_access_methods"),
+        ("has_access_info")])
+    @patch('compliance_suite.report_runner.ValidateDRSObjectResponse')
+    def test_add_access_methods_test_case(self, case_type, MockValidateDRSObjectResponse):
+
+        test_object = Mock()
+        case_description = "Test case for access methods"
+        endpoint_name = "Test endpoint"
+        response = Mock()
+        mock_validate_drs_response = Mock()
+        MockValidateDRSObjectResponse.return_value = mock_validate_drs_response
+        access_id_list = add_access_methods_test_case(test_object, case_type, case_description, endpoint_name, response)
+
+        # Assertions
+        test_object.add_case.assert_called()
+        test_case = test_object.add_case.return_value
+        test_case.set_case_name.assert_called_with(f"{endpoint_name} has access information")
+        test_case.set_case_description.assert_called_with(case_description)
+        mock_validate_drs_response.set_case.assert_called_with(test_case)
+        mock_validate_drs_response.set_actual_response.assert_called_with(response)
+        test_case.set_end_time_now.assert_called()
+
+        if case_type == "has_access_methods":
+            mock_validate_drs_response.validate_has_access_methods.assert_called()
+            mock_validate_drs_response.validate_has_access_info.assert_not_called()
+            self.assertIsNone(access_id_list)
+        else:
+            mock_validate_drs_response.validate_has_access_methods.assert_not_called()
+            mock_validate_drs_response.validate_has_access_info.assert_called()

--- a/unittests/v1.2.0/test_validate_drs_object_response.py
+++ b/unittests/v1.2.0/test_validate_drs_object_response.py
@@ -1,0 +1,43 @@
+from compliance_suite.validate_drs_object_response import *
+from unittests.resources.mock_drs_response_access_methods import *
+import unittest
+from parameterized import parameterized
+from ga4gh.testbed.report.case import Case
+
+class TestValidateDRSObjectResponse(unittest.TestCase):
+
+    def setUp(self):
+        self.validator = ValidateDRSObjectResponse()
+        self.mock_case = Case()
+
+    @parameterized.expand([
+        (mock_response_0, Status.FAIL),
+        (mock_response_1, Status.FAIL),
+        (mock_response_2, Status.PASS),
+        (mock_response_3, Status.PASS),
+        (mock_response_4, Status.PASS)
+    ])
+    def test_validate_has_access_methods(self, mock_response, expected_status):
+        self.validator.set_actual_response(mock_response)
+        self.validator.set_case(self.mock_case)
+        self.validator.validate_has_access_methods()
+        self.assertEqual(expected_status,self.validator.case.get_status())
+
+    expected_message_0 = "access_methods is not provided. It is required and should be non-empty for a single-blob"
+    expected_message_1 = "At least 'access_url' or 'access_id' is provided in all access_methods"
+    expected_message_2 = "Neither 'access_url' nor 'access_id' is provided in some or all access_methods - "
+
+    @parameterized.expand([
+        (mock_response_0, Status.FAIL, [], expected_message_0),
+        (mock_response_1, Status.FAIL, [], expected_message_0),
+        (mock_response_2, Status.PASS, ["338e433b-e0f4-4261-9d25-1863b2dcf08d"], expected_message_1),
+        (mock_response_3, Status.FAIL, ["338e433b-e0f4-4261-9d25-1863b2dcf08d"], expected_message_2 + "3"),
+        (mock_response_4, Status.PASS, ["338e433b-e0f4-4261-9d25-1863b2dcf08d", "338e433b-e0f4-4261-9d25-1863b2dcf08f"],expected_message_1)
+    ])
+    def test_validate_has_access_info(self, mock_response, expected_status, expected_access_id_list, expected_message):
+        self.validator.set_actual_response(mock_response)
+        self.validator.set_case(self.mock_case)
+        actual_access_id_list = self.validator.validate_has_access_info()
+        self.assertEqual(expected_status,self.validator.case.get_status())
+        self.assertListEqual(expected_access_id_list, actual_access_id_list, "Actual access_id list doesn't match the expected list")
+        self.assertEqual(self.validator.case.get_message(),expected_message)


### PR DESCRIPTION
- remove access_id values from input_drs_objects.json
- get list of access_ids for each drs_object from drs object endpoint response
- test to make sure "access_methods" is not null when drs_object is not a bundle. Each of the access_methods should provide atleast one of "access_url" or "access_id". If any of these rules is not satisfied, Fail the corresponding test case.
- Add unittests for the newly added code
- Fixed github actions workflow to run tests that are in the "unittests/" directory and set up "PYTHONPATH" variable