### PR TITLE
Allow null value matching in JSON schema where string is expected but not required

### DIFF
--- a/compliance_suite/schemas/v1.2.0/drs_bundle.json
+++ b/compliance_suite/schemas/v1.2.0/drs_bundle.json
@@ -13,7 +13,7 @@
           "description": "An identifier unique to this `DrsObject`"
         },
         "name": {
-          "type": "string",
+          "type": ["string", "null"],
           "description": "A string that can be used to name a `DrsObject`.\nThis string is made up of uppercase and lowercase letters, decimal digits, hypen, period, and underscore [A-Za-z0-9.-_]. See http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_282[portable filenames]."
         },
         "self_uri": {
@@ -30,16 +30,16 @@
           "description": "Timestamp of content creation in RFC3339.\n(This is the creation time of the underlying content, not of the JSON object.)"
         },
         "updated_time": {
-          "type": "string",
+          "type": ["string", "null"],
           "format": "date-time",
           "description": "Timestamp of content update in RFC3339, identical to `created_time` in systems that do not support updates. (This is the update time of the underlying content, not of the JSON object.)"
         },
         "version": {
-          "type": "string",
+          "type": ["string", "null"],
           "description": "A string representing a version. (Some systems may use checksum, a RFC3339 timestamp, or an incrementing version number.)"
         },
         "mime_type": {
-          "type": "string",
+          "type": ["string", "null"],
           "description": "A string providing the mime-type of the `DrsObject`."
         },
         "checksums": {
@@ -66,7 +66,7 @@
           }
         },
         "description": {
-          "type": "string",
+          "type": ["string", "null"],
           "description": "A human readable description of the `DrsObject`."
         },
         "aliases": {

--- a/compliance_suite/schemas/v1.2.0/drs_object.json
+++ b/compliance_suite/schemas/v1.2.0/drs_object.json
@@ -13,7 +13,7 @@
           "description": "An identifier unique to this `DrsObject`"
         },
         "name": {
-          "type": "string",
+          "type": ["string", "null"],
           "description": "A string that can be used to name a `DrsObject`.\nThis string is made up of uppercase and lowercase letters, decimal digits, hypen, period, and underscore [A-Za-z0-9.-_]. See http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_282[portable filenames]."
         },
         "self_uri": {
@@ -30,16 +30,16 @@
           "description": "Timestamp of content creation in RFC3339.\n(This is the creation time of the underlying content, not of the JSON object.)"
         },
         "updated_time": {
-          "type": "string",
+          "type": ["string", "null"],
           "format": "date-time",
           "description": "Timestamp of content update in RFC3339, identical to `created_time` in systems that do not support updates. (This is the update time of the underlying content, not of the JSON object.)"
         },
         "version": {
-          "type": "string",
+          "type": ["string", "null"],
           "description": "A string representing a version. (Some systems may use checksum, a RFC3339 timestamp, or an incrementing version number.)"
         },
         "mime_type": {
-          "type": "string",
+          "type": ["string", "null"],
           "description": "A string providing the mime-type of the `DrsObject`."
         },
         "checksums": {
@@ -66,7 +66,7 @@
           }
         },
         "description": {
-          "type": "string",
+          "type": ["string", "null"],
           "description": "A human readable description of the `DrsObject`."
         },
         "aliases": {

--- a/compliance_suite/schemas/v1.3.0/drs_object.json
+++ b/compliance_suite/schemas/v1.3.0/drs_object.json
@@ -13,7 +13,7 @@
           "description": "An identifier unique to this `DrsObject`"
         },
         "name": {
-          "type": "string",
+          "type": ["string", "null"],
           "description": "A string that can be used to name a `DrsObject`.\nThis string is made up of uppercase and lowercase letters, decimal digits, hyphen, period, and underscore [A-Za-z0-9.-_]. See http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_282[portable filenames]."
         },
         "self_uri": {
@@ -30,16 +30,16 @@
           "description": "Timestamp of content creation in RFC3339.\n(This is the creation time of the underlying content, not of the JSON object.)"
         },
         "updated_time": {
-          "type": "string",
+          "type": ["string", "null"],
           "format": "date-time",
           "description": "Timestamp of content update in RFC3339, identical to `created_time` in systems that do not support updates. (This is the update time of the underlying content, not of the JSON object.)"
         },
         "version": {
-          "type": "string",
+          "type": ["string", "null"],
           "description": "A string representing a version. (Some systems may use checksum, a RFC3339 timestamp, or an incrementing version number.)"
         },
         "mime_type": {
-          "type": "string",
+          "type": ["string", "null"],
           "description": "A string providing the mime-type of the `DrsObject`."
         },
         "checksums": {
@@ -66,7 +66,7 @@
           }
         },
         "description": {
-          "type": "string",
+          "type": ["string", "null"],
           "description": "A human readable description of the `DrsObject`."
         },
         "aliases": {


### PR DESCRIPTION
Addressing some of the feedback received during Connect for allowing null responses when a string may be the expected response. This was done by added null to the list of acceptable response types in the json schema.