### PR TITLE
Accept string or list for passport auth_token in the config file

### DIFF
--- a/compliance_suite/config/config_samples/config_passport.json
+++ b/compliance_suite/config/config_samples/config_passport.json
@@ -7,13 +7,13 @@
     {
       "drs_id" : "697907bf-d5bd-433e-aac2-1747f1faf366",
       "auth_type": "passport",
-      "auth_token": ["passport-366"],
+      "auth_token": "passport-366",
       "is_bundle": false
     },
     {
       "drs_id" : "0bb9d297-2710-48f6-ab4d-80d5eb0c9eaa",
       "auth_type": "passport",
-      "auth_token": ["passport-eaa"],
+      "auth_token": "passport-eaa",
       "is_bundle": false
     },
     {
@@ -39,7 +39,7 @@
     {
       "drs_id" : "697907bf-d5bd-433e-aac2-1747f1faf366",
       "auth_type": "passport",
-      "auth_token": ["passport-366"]
+      "auth_token": "passport-366"
     },
     {
       "drs_id" : "0bb9d297-2710-48f6-ab4d-80d5eb0c9eaa",
@@ -54,7 +54,7 @@
     {
       "drs_id" : "41898242-62a9-4129-9a2c-5a4e8f5f0afb",
       "auth_type": "passport",
-      "auth_token": ["passport-afb"]
+      "auth_token": "passport-afb"
     },
     {
       "drs_id" : "a1dd4ae2-8d26-43b0-a199-342b64c7dff6",

--- a/compliance_suite/report_runner.py
+++ b/compliance_suite/report_runner.py
@@ -289,6 +289,14 @@ def send_request(
             # endpoints that allow auth_type: "passport"
             # 1. DRS Objects: /objects/{object_id}
             # 2. DRS Object Access: /objects/{object_id}/access/{access_id}
+
+            # The `auth_token` variable, which is received from the config file, could be a string or an array of strings.
+            # If `auth_type` is set to "passport", `auth_token` should be an array of passport tokens.
+            # so, ensure auth_token is an array of strings
+            if not isinstance(auth_token, list):
+                auth_token = [str(auth_token)]
+            if isinstance(auth_token, list) and not all(isinstance(t, str) for t in auth_token):
+                auth_token = [str(t) for t in auth_token]
             request_body["passports"] = auth_token
             if ("expand" in kwargs) and (kwargs["expand"]):
                 request_body["expand"] = True


### PR DESCRIPTION
- `auth_token` can be either a string or a list of strings when `auth_type` = "passport" in the input config file
- updated report_runner.py to handle this change for auth_type = "passport"
@Chen2x Please let me know if you have any questions or feedback