### PR TITLE
New config format for the DRS compliance suite

### DIFF
--- a/compliance_suite/config/config_samples/config_passport.json
+++ b/compliance_suite/config/config_samples/config_passport.json
@@ -7,13 +7,13 @@
     {
       "drs_id" : "697907bf-d5bd-433e-aac2-1747f1faf366",
       "auth_type": "passport",
-      "auth_token": ["passport-366"],
+      "auth_token": "passport-366",
       "is_bundle": false
     },
     {
       "drs_id" : "0bb9d297-2710-48f6-ab4d-80d5eb0c9eaa",
       "auth_type": "passport",
-      "auth_token": ["passport-eaa"],
+      "auth_token": "passport-eaa",
       "is_bundle": false
     },
     {
@@ -39,7 +39,7 @@
     {
       "drs_id" : "697907bf-d5bd-433e-aac2-1747f1faf366",
       "auth_type": "passport",
-      "auth_token": ["passport-366"]
+      "auth_token": "passport-366"
     },
     {
       "drs_id" : "0bb9d297-2710-48f6-ab4d-80d5eb0c9eaa",
@@ -54,7 +54,7 @@
     {
       "drs_id" : "41898242-62a9-4129-9a2c-5a4e8f5f0afb",
       "auth_type": "passport",
-      "auth_token": ["passport-afb"]
+      "auth_token": "passport-afb"
     },
     {
       "drs_id" : "a1dd4ae2-8d26-43b0-a199-342b64c7dff6",

--- a/compliance_suite/report_runner.py
+++ b/compliance_suite/report_runner.py
@@ -289,6 +289,14 @@ def send_request(
             # endpoints that allow auth_type: "passport"
             # 1. DRS Objects: /objects/{object_id}
             # 2. DRS Object Access: /objects/{object_id}/access/{access_id}
+
+            # The `auth_token` variable, which is received from the config file, could be a string or an array of strings.
+            # If `auth_type` is set to "passport", `auth_token` should be an array of passport tokens.
+            # so, ensure auth_token is an array of strings
+            if not isinstance(auth_token, list):
+                auth_token = [str(auth_token)]
+            if isinstance(auth_token, list) and not all(isinstance(t, str) for t in auth_token):
+                auth_token = [str(t) for t in auth_token]
             request_body["passports"] = auth_token
             if ("expand" in kwargs) and (kwargs["expand"]):
                 request_body["expand"] = True

--- a/compliance_suite/schemas/v1.2.0/access_method.json
+++ b/compliance_suite/schemas/v1.2.0/access_method.json
@@ -26,11 +26,11 @@
           "description": "An `AccessURL` that can be used to fetch the actual object bytes. Note that at least one of `access_url` and `access_id` must be provided."
         },
         "access_id": {
-          "type": "string",
+          "type": ["string", "null"],
           "description": "An arbitrary string to be passed to the `/access` method to get an `AccessURL`. This string must be unique within the scope of a single object. Note that at least one of `access_url` and `access_id` must be provided."
         },
         "region": {
-          "type": "string",
+          "type": ["string", "null"],
           "description": "Name of the region in the cloud service provider that the object belongs to."
         }
       },

--- a/compliance_suite/schemas/v1.2.0/contents_object.json
+++ b/compliance_suite/schemas/v1.2.0/contents_object.json
@@ -12,7 +12,7 @@
           "description": "A name declared by the bundle author that must be used when materialising this object, overriding any name directly associated with the object itself. The name must be unique with the containing bundle. This string is made up of uppercase and lowercase letters, decimal digits, hypen, period, and underscore [A-Za-z0-9.-_]. See http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_282[portable filenames]."
         },
         "id": {
-          "type": "string",
+          "type": ["string", "null"],
           "description": "A DRS identifier of a `DrsObject` (either a single blob or a nested bundle). If this ContentsObject is an object within a nested bundle, then the id is optional. Otherwise, the id is required."
         },
         "drs_uri": {

--- a/compliance_suite/schemas/v1.2.0/drs_bundle.json
+++ b/compliance_suite/schemas/v1.2.0/drs_bundle.json
@@ -52,7 +52,6 @@
         },
         "access_methods": {
           "type": "array",
-          "minItems": 1,
           "items": {
             "$ref": "access_method.json#/definitions/access_method"
           },
@@ -61,6 +60,7 @@
         "contents": {
           "type": "array",
           "description": "If not set, this `DrsObject` is a single blob. If set, this `DrsObject` is a bundle containing the listed `ContentsObject` s (some of which may be further nested).",
+          "minItems": 1,
           "items": {
             "$ref": "contents_object.json#/definitions/contents_object"
           }

--- a/compliance_suite/schemas/v1.2.0/drs_bundle.json
+++ b/compliance_suite/schemas/v1.2.0/drs_bundle.json
@@ -13,7 +13,7 @@
           "description": "An identifier unique to this `DrsObject`"
         },
         "name": {
-          "type": "string",
+          "type": ["string", "null"],
           "description": "A string that can be used to name a `DrsObject`.\nThis string is made up of uppercase and lowercase letters, decimal digits, hypen, period, and underscore [A-Za-z0-9.-_]. See http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_282[portable filenames]."
         },
         "self_uri": {
@@ -30,16 +30,16 @@
           "description": "Timestamp of content creation in RFC3339.\n(This is the creation time of the underlying content, not of the JSON object.)"
         },
         "updated_time": {
-          "type": "string",
+          "type": ["string", "null"],
           "format": "date-time",
           "description": "Timestamp of content update in RFC3339, identical to `created_time` in systems that do not support updates. (This is the update time of the underlying content, not of the JSON object.)"
         },
         "version": {
-          "type": "string",
+          "type": ["string", "null"],
           "description": "A string representing a version. (Some systems may use checksum, a RFC3339 timestamp, or an incrementing version number.)"
         },
         "mime_type": {
-          "type": "string",
+          "type": ["string", "null"],
           "description": "A string providing the mime-type of the `DrsObject`."
         },
         "checksums": {
@@ -66,7 +66,7 @@
           }
         },
         "description": {
-          "type": "string",
+          "type": ["string", "null"],
           "description": "A human readable description of the `DrsObject`."
         },
         "aliases": {

--- a/compliance_suite/schemas/v1.2.0/drs_object.json
+++ b/compliance_suite/schemas/v1.2.0/drs_object.json
@@ -82,6 +82,7 @@
         "self_uri",
         "size",
         "created_time",
+        "access_methods",
         "checksums"
       ],
       "additionalProperties": true

--- a/compliance_suite/schemas/v1.2.0/drs_object.json
+++ b/compliance_suite/schemas/v1.2.0/drs_object.json
@@ -13,7 +13,7 @@
           "description": "An identifier unique to this `DrsObject`"
         },
         "name": {
-          "type": "string",
+          "type": ["string", "null"],
           "description": "A string that can be used to name a `DrsObject`.\nThis string is made up of uppercase and lowercase letters, decimal digits, hypen, period, and underscore [A-Za-z0-9.-_]. See http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_282[portable filenames]."
         },
         "self_uri": {
@@ -30,16 +30,16 @@
           "description": "Timestamp of content creation in RFC3339.\n(This is the creation time of the underlying content, not of the JSON object.)"
         },
         "updated_time": {
-          "type": "string",
+          "type": ["string", "null"],
           "format": "date-time",
           "description": "Timestamp of content update in RFC3339, identical to `created_time` in systems that do not support updates. (This is the update time of the underlying content, not of the JSON object.)"
         },
         "version": {
-          "type": "string",
+          "type": ["string", "null"],
           "description": "A string representing a version. (Some systems may use checksum, a RFC3339 timestamp, or an incrementing version number.)"
         },
         "mime_type": {
-          "type": "string",
+          "type": ["string", "null"],
           "description": "A string providing the mime-type of the `DrsObject`."
         },
         "checksums": {
@@ -66,7 +66,7 @@
           }
         },
         "description": {
-          "type": "string",
+          "type": ["string", "null"],
           "description": "A human readable description of the `DrsObject`."
         },
         "aliases": {

--- a/compliance_suite/schemas/v1.2.0/error.json
+++ b/compliance_suite/schemas/v1.2.0/error.json
@@ -9,7 +9,7 @@
       "type": "object",
       "properties": {
         "msg": {
-          "type": "string",
+          "type": ["string", "null"],
           "description": "A detailed error message."
         },
         "status_code": {

--- a/compliance_suite/schemas/v1.3.0/access_method.json
+++ b/compliance_suite/schemas/v1.3.0/access_method.json
@@ -35,11 +35,11 @@
           ]
         },
         "access_id": {
-          "type": "string",
+          "type": ["string", "null"],
           "description": "An arbitrary string to be passed to the `/access` method to get an `AccessURL`. This string must be unique within the scope of a single object. Note that at least one of `access_url` and `access_id` must be provided."
         },
         "region": {
-          "type": "string",
+          "type": ["string", "null"],
           "description": "Name of the region in the cloud service provider that the object belongs to.",
           "example": "us-east-1"
         },

--- a/compliance_suite/schemas/v1.3.0/contents_object.json
+++ b/compliance_suite/schemas/v1.3.0/contents_object.json
@@ -12,7 +12,7 @@
           "description": "A name declared by the bundle author that must be used when materialising this object, overriding any name directly associated with the object itself. The name must be unique within the containing bundle. This string is made up of uppercase and lowercase letters, decimal digits, hyphen, period, and underscore [A-Za-z0-9.-_]. See http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_282[portable filenames]."
         },
         "id": {
-          "type": "string",
+          "type": ["string", "null"],
           "description": "A DRS identifier of a `DrsObject` (either a single blob or a nested bundle). If this ContentsObject is an object within a nested bundle, then the id is optional. Otherwise, the id is required."
         },
         "drs_uri": {

--- a/compliance_suite/schemas/v1.3.0/drs_bundle.json
+++ b/compliance_suite/schemas/v1.3.0/drs_bundle.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "DRS object info",
+  "description": "DRS object info v1.3",
+  "type": "object",
+  "$ref": "drs_bundle.json#/definitions/drs_bundle",
+  "definitions": {
+    "drs_bundle": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "An identifier unique to this `DrsObject`"
+        },
+        "name": {
+          "type": ["string", "null"],
+          "description": "A string that can be used to name a `DrsObject`.\nThis string is made up of uppercase and lowercase letters, decimal digits, hypen, period, and underscore [A-Za-z0-9.-_]. See http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_282[portable filenames]."
+        },
+        "self_uri": {
+          "type": "string",
+          "description": "A drs:// hostname-based URI, as defined in the DRS documentation, that tells clients how to access this object.\nThe intent of this field is to make DRS objects self-contained, and therefore easier for clients to store and pass around.  For example, if you arrive at this DRS JSON by resolving a compact identifier-based DRS URI, the `self_uri` presents you with a hostname and properly encoded DRS ID for use in subsequent `access` endpoint calls."
+        },
+        "size": {
+          "type": "integer",
+          "description": "For blobs, the blob size in bytes.\nFor bundles, the cumulative size, in bytes, of items in the `contents` field."
+        },
+        "created_time": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp of content creation in RFC3339.\n(This is the creation time of the underlying content, not of the JSON object.)"
+        },
+        "updated_time": {
+          "type": ["string", "null"],
+          "format": "date-time",
+          "description": "Timestamp of content update in RFC3339, identical to `created_time` in systems that do not support updates. (This is the update time of the underlying content, not of the JSON object.)"
+        },
+        "version": {
+          "type": ["string", "null"],
+          "description": "A string representing a version. (Some systems may use checksum, a RFC3339 timestamp, or an incrementing version number.)"
+        },
+        "mime_type": {
+          "type": ["string", "null"],
+          "description": "A string providing the mime-type of the `DrsObject`."
+        },
+        "checksums": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "checksum.json#/definitions/checksum"
+          },
+          "description": "The checksum of the `DrsObject`. At least one checksum must be provided. For blobs, the checksum is computed over the bytes in the blob. For bundles, the checksum is computed over a sorted concatenation of the checksums of its top-level contained objects (not recursive, names not included). The list of checksums is sorted alphabetically (hex-code) before concatenation and a further checksum is performed on the concatenated checksum value. For example, if a bundle contains blobs with the following checksums: md5(blob1) = 72794b6d md5(blob2) = 5e089d29 Then the checksum of the bundle is: md5( concat( sort( md5(blob1), md5(blob2) ) ) ) = md5( concat( sort( 72794b6d, 5e089d29 ) ) ) = md5( concat( 5e089d29, 72794b6d ) ) = md5( 5e089d2972794b6d ) = f7a29a04"
+        },
+        "access_methods": {
+          "type": "array",
+          "items": {
+            "$ref": "access_method.json#/definitions/access_method"
+          },
+          "description": "The list of access methods that can be used to fetch the `DrsObject`.\nRequired for single blobs; optional for bundles."
+        },
+        "contents": {
+          "type": "array",
+          "description": "If not set, this `DrsObject` is a single blob. If set, this `DrsObject` is a bundle containing the listed `ContentsObject` s (some of which may be further nested).",
+          "minItems": 1,
+          "items": {
+            "$ref": "contents_object.json#/definitions/contents_object"
+          }
+        },
+        "description": {
+          "type": ["string", "null"],
+          "description": "A human readable description of the `DrsObject`."
+        },
+        "aliases": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "A list of strings that can be used to find other metadata about this `DrsObject` from external metadata sources. These aliases can be used to represent secondary accession numbers or external GUIDs."
+        }
+      },
+      "required": [
+        "id",
+        "self_uri",
+        "size",
+        "created_time",
+        "checksums",
+        "contents"
+      ],
+      "additionalProperties": true
+    }
+  }
+}

--- a/compliance_suite/schemas/v1.3.0/drs_object.json
+++ b/compliance_suite/schemas/v1.3.0/drs_object.json
@@ -13,7 +13,7 @@
           "description": "An identifier unique to this `DrsObject`"
         },
         "name": {
-          "type": "string",
+          "type": ["string", "null"],
           "description": "A string that can be used to name a `DrsObject`.\nThis string is made up of uppercase and lowercase letters, decimal digits, hyphen, period, and underscore [A-Za-z0-9.-_]. See http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_282[portable filenames]."
         },
         "self_uri": {
@@ -30,16 +30,16 @@
           "description": "Timestamp of content creation in RFC3339.\n(This is the creation time of the underlying content, not of the JSON object.)"
         },
         "updated_time": {
-          "type": "string",
+          "type": ["string", "null"],
           "format": "date-time",
           "description": "Timestamp of content update in RFC3339, identical to `created_time` in systems that do not support updates. (This is the update time of the underlying content, not of the JSON object.)"
         },
         "version": {
-          "type": "string",
+          "type": ["string", "null"],
           "description": "A string representing a version. (Some systems may use checksum, a RFC3339 timestamp, or an incrementing version number.)"
         },
         "mime_type": {
-          "type": "string",
+          "type": ["string", "null"],
           "description": "A string providing the mime-type of the `DrsObject`."
         },
         "checksums": {
@@ -66,7 +66,7 @@
           }
         },
         "description": {
-          "type": "string",
+          "type": ["string", "null"],
           "description": "A human readable description of the `DrsObject`."
         },
         "aliases": {

--- a/compliance_suite/schemas/v1.3.0/drs_object.json
+++ b/compliance_suite/schemas/v1.3.0/drs_object.json
@@ -82,6 +82,7 @@
         "self_uri",
         "size",
         "created_time",
+        "access_methods",
         "checksums"
       ],
       "additionalProperties": true

--- a/compliance_suite/schemas/v1.3.0/error.json
+++ b/compliance_suite/schemas/v1.3.0/error.json
@@ -9,7 +9,7 @@
       "type": "object",
       "properties": {
         "msg": {
-          "type": "string",
+          "type": ["string", "null"],
           "description": "A detailed error message."
         },
         "status_code": {

--- a/config/config_schema.json
+++ b/config/config_schema.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "DRS Compliance Suite Config",
+  "description": "DRS Compliance Suite Config v1.2",
+  "type": "object",
+  "$ref": "config_schema.json#/definitions/config_schema",
+  "definitions": {
+    "config_schema": {
+      "type": "object",
+      "properties": {
+        "default_auth_info": {
+          "type": "object",
+          "description": "Default auth type and token for the server",
+          "properties": {
+            "auth_type": {
+              "type": "string",
+              "description": "The default auth type for DRS object access"
+            },
+            "auth_token": {
+              "type": "string",
+              "description": "The default auth token for DRS object access"
+            }
+          }
+        },
+        "drs_objects":{
+          "type": "array",
+          "items": {
+            "drs_object": {
+              "type": "object",
+              "properties": {
+                "drs_id": {
+                  "type": "string",
+                  "description": "The DRS ID of the object"
+                },
+                "expected_status_code": {
+                  "type": "integer",
+                  "description": "The expected status code for testing the DRS object"
+                },
+                "has_auth_get_object": {
+                  "type": "boolean",
+                  "description": "True if get object endpoint requires auth info"
+                },
+                "is_bundle": {
+                  "type": "boolean",
+                  "description": "True if DRS object is bundle"
+                },
+                "auth_info":{
+                  "type": "object",
+                  "description": "Contains auth type and token if different than default auth",
+                  "properties": {
+                    "auth_type": {
+                      "type": "string",
+                      "description": "Auth type for current DRS object"
+                    },
+                    "auth_token": {
+                      "type": ["string", "array"],
+                      "items": {
+                          "type": "string",
+                          "description": "Auth token for current DRS object"
+                      }
+                    }
+                  }  
+                }  
+              },
+              "required": [
+                "drs_id"
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/config/sample_config.json
+++ b/config/sample_config.json
@@ -1,0 +1,51 @@
+{
+  "default_auth_info":
+  {
+    "auth_type": "passport",
+    "auth_token": "passport_token_2.txt"
+  },
+  "drs_objects":
+  [
+    {
+      "drs_id": "697907bf-d5bd-433e-aac2-1747f1faf366",
+      "expected_status_code": 200
+    },
+    {
+      "drs_id": "0bb9d297-2710-48f6-ab4d-80d5eb0c9eaa",
+      "expected_status_code": 200
+    },
+    {
+      "drs_id": "1af6b862-7fc8-411a-86c5-d8e280e5b77a",
+      "auth_info":
+      {
+        "auth_type": "basic",
+        "auth_token": "basic_token_1.txt"
+      },
+      "expected_status_code": 400
+    },
+    {
+      "drs_id": "41898242-62a9-4129-9a2c-5a4e8f5f0afb",
+      "auth_info":
+      {
+        "auth_type": "bearer",
+        "auth_token": "bearer_token_1.txt"
+      },
+      "has_auth_get_object": true,
+      "expected_status_code": 200
+    },
+    {
+      "drs_id": "a1dd4ae2-8d26-43b0-a199-342b64c7dff6",
+      "auth_info":
+      {
+        "auth_type": "passport",
+        "auth_token":
+        [
+          "passport_token_1.txt",
+          "passport_token_2.txt"
+        ]
+      },
+      "is_bundle": true,
+      "expected_status_code": 200
+    }
+  ]
+}


### PR DESCRIPTION
A new config design based on the feedback from the DRS test a thon held at connect for loading DRS objects into the compliance suite as well as a json schema.